### PR TITLE
Capture testcase code in test report

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -97,7 +97,7 @@ export default class SauceReporter implements Reporter {
     const jobUrls = [];
     const suites = [];
     for await (const projectSuite of this.rootSuite.suites) {
-      const { report, assets } = await this.createSauceReport(projectSuite);
+      const { report, assets } = this.createSauceReport(projectSuite);
 
       const result = await this.reportToSauce(projectSuite, report, assets);
 
@@ -190,7 +190,7 @@ export default class SauceReporter implements Reporter {
     return consoleLog;
   }
 
-  async constructSauceSuite (rootSuite: PlaywrightSuite) {
+  constructSauceSuite (rootSuite: PlaywrightSuite) {
     const suite = new SauceSuite(rootSuite.title);
     const assets : Asset[] = [];
 
@@ -203,7 +203,7 @@ export default class SauceReporter implements Reporter {
         break;
       }
 
-      const lines = await getLines(testCase);
+      const lines = getLines(testCase);
 
       const isSkipped = testCase.outcome() === 'skipped';
       const test = suite.withTest(testCase.title, {
@@ -253,8 +253,8 @@ export default class SauceReporter implements Reporter {
       }
     }
 
-    for await (const subSuite of rootSuite.suites) {
-      const { suite: s, assets: a } = await this.constructSauceSuite(subSuite);
+    for (const subSuite of rootSuite.suites) {
+      const { suite: s, assets: a } = this.constructSauceSuite(subSuite);
       suite.addSuite(s);
 
       assets.push(...a);
@@ -273,8 +273,8 @@ ${err.stack}
     `;
   }
 
-  async createSauceReport (rootSuite: PlaywrightSuite) {
-    const { suite: sauceSuite, assets } = await this.constructSauceSuite(rootSuite);
+  createSauceReport (rootSuite: PlaywrightSuite) {
+    const { suite: sauceSuite, assets } = this.constructSauceSuite(rootSuite);
 
     const report = new TestRun();
     report.addSuite(sauceSuite);


### PR DESCRIPTION
For each TestCase, read the lines of code from the test file of the executed TestSteps and add them to the test report.

Note, the Playwright api only returns the file locations of the `TestStep`s for a given `TestCase` so we can't get the full definition of a `TestCase`.

e.g. For this TestCase:
```javascript
test('should verify title of the page', async ({ page }, testInfo) => {
  await page.goto('https://www.saucedemo.com/');

  const path = testInfo.outputPath('screenshot.png');
  await page.screenshot({ path });
  testInfo.attachments.push({ name: 'screenshot', path, contentType: 'image/png' });

  expect(await page.title()).toBe('Swag Labs');
});
```
We'd get:
```
[
  "await page.goto('https://www.saucedemo.com/');",
  'await page.screenshot({ path });',
  "expect(await page.title()).toBe('Swag Labs');"
]
```