### PR TITLE
[DEVX-1973] Set default value for root suite name

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -189,7 +189,7 @@ export default class SauceReporter implements Reporter {
   }
 
   constructSauceSuite (rootSuite: PlaywrightSuite) {
-    const suite = new SauceSuite(rootSuite.title);
+    const suite = new SauceSuite(rootSuite.title || 'chromium');
     const assets : Asset[] = [];
 
     for (const testCase of rootSuite.tests) {


### PR DESCRIPTION
Given empty browser setting for playwright, e.g, `npx playwright test  --reporter=line,@saucelabs/playwright-reporter`, the root suite name is empty. Web page would show ` - tests/example.test.js` for the suite name. 
Before 
<img width="982" alt="Screen Shot 2022-10-26 at 9 21 45 AM" src="https://user-images.githubusercontent.com/71669683/198081025-7bce3cf9-9d0c-4a32-9bea-955a9b0ed112.png">
After
<img width="982" alt="Screen Shot 2022-10-26 at 9 23 18 AM" src="https://user-images.githubusercontent.com/71669683/198081132-dd707b99-adbf-4f6d-9398-55885f49da2b.png">
