### PR TITLE
feat: Sync attachments to assets directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ node
 
 Cache/
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ const config = {
 };
 ```
 
-| Name | Description | Kind |
-| --- | --- | --- |
-| build | Sets a build ID. (Default: `''`) | String |
-| tags | Tags to add to the uploaded Sauce job. (Default: `[]`) | String[] |
-| region | Sets the region. (Default: `us-west-1`) | `us-west-1` \| `eu-central-1` |
-| upload | Whether to upload report and assets to Sauce (Default: `true`) | boolean |
-| outputFile | The local path to write the sauce test report. | String |
+| Name           | Description                                                                                                                 | Kind                         |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------|------------------------------|
+| `build`        | Sets a build ID. <br> Default: `''`                                                                                         | `String`                     |
+| `tags`         | Tags to add to the uploaded Sauce job. <br> Default: `[]`                                                                   | `String[]`                   |
+| `region`       | Sets the region. <br> Default: `us-west-1`                                                                                  | `us-west-1` \| `eu-central-1`|
+| `upload`       | Whether to upload report and assets to Sauce <br> Default: `true`                                                           | `boolean`                    |
+| `outputFile`   | The local path to write the sauce test report. Can be set in env var `SAUCE_REPORT_OUTPUT_NAME`.                            | `String`                     |
+| `syncAssetsDir`| Set the destination folder for syncing attachments. This can be configured via the `SAUCE_ASSETS_DIR` environment variable. | `String`                     |
 
-You can also use the `SAUCE_REPORT_OUTPUT_NAME` environment variable as an alternative to the `outputFile` reporter option in your playwright config.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ const config = {
 };
 ```
 
-| Name           | Description                                                                                                                 | Kind                         |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------|------------------------------|
-| `build`        | Sets a build ID. <br> Default: `''`                                                                                         | `String`                     |
-| `tags`         | Tags to add to the uploaded Sauce job. <br> Default: `[]`                                                                   | `String[]`                   |
-| `region`       | Sets the region. <br> Default: `us-west-1`                                                                                  | `us-west-1` \| `eu-central-1`|
-| `upload`       | Whether to upload report and assets to Sauce <br> Default: `true`                                                           | `boolean`                    |
-| `outputFile`   | The local path to write the sauce test report. Can be set in env var `SAUCE_REPORT_OUTPUT_NAME`.                            | `String`                     |
-| `syncAssetsDir`| Set the destination folder for syncing attachments. This can be configured via the `SAUCE_ASSETS_DIR` environment variable. | `String`                     |
+| Name           | Description                                                                                                                      | Kind                         |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------|
+| `build`        | Sets a build ID. <br> Default: `''`                                                                                              | `String`                     |
+| `tags`         | Tags to add to the uploaded Sauce job. <br> Default: `[]`                                                                        | `String[]`                   |
+| `region`       | Sets the region. <br> Default: `us-west-1`                                                                                       | `us-west-1` \| `eu-central-1`|
+| `upload`       | Whether to upload report and assets to Sauce <br> Default: `true`                                                                | `boolean`                    |
+| `outputFile`   | The local path to write the sauce test report. Can be set in env var `SAUCE_REPORT_OUTPUT_NAME`.                                 | `String`                     |
+| `syncAssetsDir`| Set the destination folder for syncing attachments. This can be configured via the `SAUCE_SYNC_ASSETS_DIR` environment variable. | `String`                     |
 
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -60,15 +60,13 @@ const config = {
 };
 ```
 
-| Name           | Description                                                                                                                      | Kind                         |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------|------------------------------|
-| `build`        | Sets a build ID. <br> Default: `''`                                                                                              | `String`                     |
-| `tags`         | Tags to add to the uploaded Sauce job. <br> Default: `[]`                                                                        | `String[]`                   |
-| `region`       | Sets the region. <br> Default: `us-west-1`                                                                                       | `us-west-1` \| `eu-central-1`|
-| `upload`       | Whether to upload report and assets to Sauce <br> Default: `true`                                                                | `boolean`                    |
-| `outputFile`   | The local path to write the sauce test report. Can be set in env var `SAUCE_REPORT_OUTPUT_NAME`.                                 | `String`                     |
-| `syncAssetsDir`| Set the destination folder for syncing attachments. This can be configured via the `SAUCE_SYNC_ASSETS_DIR` environment variable. | `String`                     |
-
+| Name           | Description                                                                                      | Kind                         |
+|----------------|--------------------------------------------------------------------------------------------------|------------------------------|
+| `build`        | Sets a build ID. <br> Default: `''`                                                              | `String`                     |
+| `tags`         | Tags to add to the uploaded Sauce job. <br> Default: `[]`                                        | `String[]`                   |
+| `region`       | Sets the region. <br> Default: `us-west-1`                                                       | `us-west-1` \| `eu-central-1`|
+| `upload`       | Whether to upload report and assets to Sauce <br> Default: `true`                                | `boolean`                    |
+| `outputFile`   | The local path to write the sauce test report. Can be set in env var `SAUCE_REPORT_OUTPUT_NAME`. | `String`                     |
 
 ## Limitations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "3.0.3",
-        "@saucelabs/testcomposer": "^1.2.1",
+        "@saucelabs/testcomposer": "2.0.1",
         "axios": "1.5.1",
         "debug": "^4.3.4"
       },
@@ -1545,12 +1545,15 @@
       }
     },
     "node_modules/@saucelabs/testcomposer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-1.2.1.tgz",
-      "integrity": "sha512-kYyx2vul32SOJa6iSZK6mKj69r+y73SOO05KcjvWUQ62n4KlKAJChPHPdzWR0Lh4/uGBhDdVyy9f8aC6UTZW9w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-2.0.1.tgz",
+      "integrity": "sha512-AJdnneRZbZujTVgDE8nmPBzf64hEC1kpzGWFU2cAxDJFk/XIGNNZkU8becY4tBEpzDMF57ePvAOW9Bfe++kPdA==",
       "dependencies": {
-        "axios": "^1.0.0",
+        "axios": "^1.5.1",
         "form-data": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.13.2"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -10540,11 +10543,11 @@
       }
     },
     "@saucelabs/testcomposer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-1.2.1.tgz",
-      "integrity": "sha512-kYyx2vul32SOJa6iSZK6mKj69r+y73SOO05KcjvWUQ62n4KlKAJChPHPdzWR0Lh4/uGBhDdVyy9f8aC6UTZW9w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@saucelabs/testcomposer/-/testcomposer-2.0.1.tgz",
+      "integrity": "sha512-AJdnneRZbZujTVgDE8nmPBzf64hEC1kpzGWFU2cAxDJFk/XIGNNZkU8becY4tBEpzDMF57ePvAOW9Bfe++kPdA==",
       "requires": {
-        "axios": "^1.0.0",
+        "axios": "^1.5.1",
         "form-data": "^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/saucelabs/sauce-playwright-reporter#readme",
   "dependencies": {
     "@saucelabs/sauce-json-reporter": "3.0.3",
-    "@saucelabs/testcomposer": "^1.2.1",
+    "@saucelabs/testcomposer": "2.0.1",
     "axios": "1.5.1",
     "debug": "^4.3.4"
   },

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -540,7 +540,7 @@ ${err.stack}
   }
 
   // Check if asset syncing to webAssetDir is enabled.
-  isSyncAssetEnabled(): boolean {
+  isWebAssetSyncEnabled(): boolean {
     return !!this.webAssetsDir;
   }
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -544,8 +544,8 @@ ${err.stack}
     return !!this.webAssetsDir;
   }
 
-  // Checks if the file type of a given filename is among the types allowed for syncing.
-  isAssetTypeSyncable(filename: string): boolean {
+  // Checks if the file is allowed for syncing.
+  isAssetSyncable(filename: string): boolean {
     return webAssetsTypes.includes(path.extname(filename));
   }
 
@@ -563,7 +563,7 @@ ${err.stack}
     if (
       !filename ||
       !this.isSyncAssetEnabled() ||
-      !this.isAssetTypeSyncable(filename)
+      !this.isAssetSyncable(filename)
     ) {
       return filename;
     }
@@ -573,7 +573,7 @@ ${err.stack}
   // Copy Playwright-generated assets to webAssetsDir.
   syncAssets(assets: Asset[]) {
     assets.forEach((asset) => {
-      if (this.isAssetTypeSyncable(asset.filename) && asset.path) {
+      if (this.isAssetSyncable(asset.filename) && asset.path) {
         fs.copyFileSync(
           asset.path,
           path.join(this.webAssetsDir || '', asset.filename),

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -188,7 +188,7 @@ export default class SauceReporter implements Reporter {
 
       suites.push(...report.suites);
 
-      if (this.isSyncAssetEnabled()) {
+      if (this.isWebAssetSyncEnabled()) {
         this.syncAssets(assets);
       }
     }
@@ -562,8 +562,8 @@ ${err.stack}
   resolveAssetName(testName: string, filename: string): string {
     if (
       !filename ||
-      !this.isSyncAssetEnabled() ||
-      !this.isAssetSyncable(filename)
+      !this.isWebAssetSyncEnabled() ||
+      !this.isWebAsset(filename)
     ) {
       return filename;
     }
@@ -573,7 +573,7 @@ ${err.stack}
   // Copy Playwright-generated assets to webAssetsDir.
   syncAssets(assets: Asset[]) {
     assets.forEach((asset) => {
-      if (this.isAssetSyncable(asset.filename) && asset.path) {
+      if (this.isWebAsset(asset.filename) && asset.path) {
         fs.copyFileSync(
           asset.path,
           path.join(this.webAssetsDir || '', asset.filename),

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -81,7 +81,7 @@ export default class SauceReporter implements Reporter {
     this.shouldUpload = reporterConfig?.upload !== false;
 
     this.syncAssetsDir =
-      reporterConfig.syncAssetsDir || process.env.SAUCE_ASSETS_DIR;
+      reporterConfig.syncAssetsDir || process.env.SAUCE_SYNC_ASSETS_DIR;
     if (this.syncAssetsDir && !fs.existsSync(this.syncAssetsDir)) {
       fs.mkdirSync(this.syncAssetsDir, { recursive: true });
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -168,7 +168,7 @@ export default class SauceReporter implements Reporter {
 
       suites.push(...report.suites);
 
-      if (this.syncAssetsDir) {
+      if (this.isSyncAssetEnabled()) {
         this.syncAssets(assets, this.syncAssetsDir);
       }
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -553,7 +553,10 @@ ${err.stack}
   syncAssets(assets: Asset[]) {
     assets.forEach((asset) => {
       if (this.isAssetTypeSyncable(asset.filename) && asset.path) {
-        fs.copyFileSync(asset.path, path.join(this.syncAssetsDir, asset.filename));
+        fs.copyFileSync(
+          asset.path,
+          path.join(this.syncAssetsDir, asset.filename),
+        );
       }
     });
   }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -39,6 +39,7 @@ const syncAssetsTypes = [
   '.log',
   '.json',
   '.xml',
+  '.txt',
   '.mp4',
   '.webm',
   '.png',
@@ -56,6 +57,12 @@ export default class SauceReporter implements Reporter {
   region: Region;
   outputFile?: string;
   shouldUpload: boolean;
+  /*
+   * When syncAssetsDir is set, this reporter syncs web UI-related attachments
+   * from the Playwright output directory to the specified sync assets directory.
+   * It can be specified through reportConfig.syncAssetsDir or
+   * the SAUCE_SYNC_ASSETS_DIR environment variable.
+   */
   syncAssetsDir?: string;
 
   api?: TestComposer;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -169,7 +169,7 @@ export default class SauceReporter implements Reporter {
       suites.push(...report.suites);
 
       if (this.isSyncAssetEnabled()) {
-        this.syncAssets(assets, this.syncAssetsDir);
+        this.syncAssets(assets);
       }
     }
 
@@ -550,10 +550,10 @@ ${err.stack}
     return `${testName}-${filename}`;
   }
 
-  syncAssets(assets: Asset[], assetDir: string) {
+  syncAssets(assets: Asset[]) {
     assets.forEach((asset) => {
       if (this.isAssetTypeSyncable(asset.filename) && asset.path) {
-        fs.copyFileSync(asset.path, path.join(assetDir, asset.filename));
+        fs.copyFileSync(asset.path, path.join(this.syncAssetsDir, asset.filename));
       }
     });
   }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -35,6 +35,7 @@ export interface Config {
   syncAssetsDir: string;
 }
 
+// Types of attachments relevant for UI display.
 const syncAssetsTypes = [
   '.log',
   '.json',
@@ -62,6 +63,18 @@ export default class SauceReporter implements Reporter {
    * from the Playwright output directory to the specified sync assets directory.
    * It can be specified through reportConfig.syncAssetsDir or
    * the SAUCE_SYNC_ASSETS_DIR environment variable.
+   * Designed exclusively for Sauce VM.
+   *
+   * Background: A flat uploading approach previously led to file overwrites when
+   * files from different directories shared names, which is a common scenario in
+   * Playwright tests.
+   * We've introduced the saucectl retain artifact feature to bundle the entire
+   * Playwright output folder, preventing such overwrites but leading to the upload
+   * of duplicate assets.
+   *
+   * With changes in the Playwright runner that separate the output from the sauce
+   * assets directory, this feature now copies only necessary attachments,
+   * avoiding duplicate assets and supporting UI display requirements.
    */
   syncAssetsDir?: string;
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -544,7 +544,7 @@ ${err.stack}
     return !!this.webAssetsDir;
   }
 
-  // Checks if the file is allowed for syncing.
+  // Checks if the file type of a given filename is among the types allowed for syncing.
   isAssetSyncable(filename: string): boolean {
     return webAssetsTypes.includes(path.extname(filename));
   }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -562,7 +562,7 @@ ${err.stack}
       if (this.isAssetTypeSyncable(asset.filename) && asset.path) {
         fs.copyFileSync(
           asset.path,
-          path.join(this.syncAssetsDir, asset.filename),
+          path.join(this.syncAssetsDir || '', asset.filename),
         );
       }
     });

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -544,8 +544,8 @@ ${err.stack}
     return !!this.webAssetsDir;
   }
 
-  // Checks if the file type of a given filename is among the types allowed for syncing.
-  isAssetSyncable(filename: string): boolean {
+  // Checks if the file type of a given filename is among the types compatible with the Sauce Labs web UI.
+  isWebAsset(filename: string): boolean {
     return webAssetsTypes.includes(path.extname(filename));
   }
 


### PR DESCRIPTION
# One-line summary

## Description

Sync attachment that may be of interest to the UI (log files, screenshots) over to the assets folder.

Job example: https://app.saucelabs.com/tests/8231009b273242c68458bc13906a9486