### PR TITLE
fix: incorrect handling of test results that never ran properly

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -182,7 +182,7 @@ export default class SauceReporter implements Reporter {
         try {
           await this.reportTestRun(projectSuite, report, result?.id);
         } catch (e: any) {
-          console.warn('failed to send report to insights, ', e.stack());
+          console.warn('failed to send report to insights: ', e);
         }
       }
 
@@ -244,6 +244,10 @@ export default class SauceReporter implements Reporter {
     let duration = 0;
     for (const suite of projectSuite.suites) {
       suite.tests.forEach((t: TestCase) => {
+        if (t.results.length < 1) {
+          return;
+        }
+
         const lastResult = t.results[t.results.length - 1];
         duration += lastResult.duration;
       });
@@ -255,6 +259,10 @@ export default class SauceReporter implements Reporter {
     const errors: TestRunError[] = [];
     for (const suite of projectSuite.suites) {
       suite.tests.forEach((t: TestCase) => {
+        if (t.results.length < 1) {
+          return;
+        }
+
         const lastResult = t.results[t.results.length - 1];
         if (lastResult.error) {
           errors.push(lastResult.error);


### PR DESCRIPTION
## Description

A test may never have run correctly to completion—worker crashed—and therefore never had any results. The reporter would fail multiple times in this case:

1. `stack` is not a method on Error.

```
Error in reporter TypeError: e.stack is not a function
    at SauceReporter.onEnd (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:155:75)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at ReporterV2Wrapper.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/reporterV2.js:91:12)
    at wrapAsync (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/multiplexer.js:79:12)
    at Multiplexer.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/multiplexer.js:51:25)
    at InternalReporter.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/internalReporter.js:69:12)
    at Runner.runAllTests (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/runner/runner.js:78:28)
    at runTests (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/program.js:207:85)
    at t.<anonymous> (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/program.js:54:7)
```

2. `duration` could not be calculated correctly because the code was expecting test results:
```
failed to send report to insights,  TypeError: Cannot read properties of undefined (reading 'duration')
    at forEach (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:207:40)
    at Array.forEach (<anonymous>)
    at SauceReporter.getDuration (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:205:25)
    at SauceReporter.reportTestRun (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:177:28)
    at SauceReporter.onEnd (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:152:32)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at ReporterV2Wrapper.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/reporterV2.js:91:12)
    at wrapAsync (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/multiplexer.js:79:12)
    at Multiplexer.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/multiplexer.js:51:25)
    at InternalReporter.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/internalReporter.js:69:12)
    at Runner.runAllTests (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/runner/runner.js:78:28)
    at runTests (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/program.js:207:85)
    at t.<anonymous> (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/program.js:54:7)
```

3. Same as 2. but for `error`:
```
failed to send report to insights:  TypeError: Cannot read properties of undefined (reading 'error')
    at forEach (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:222:32)
    at Array.forEach (<anonymous>)
    at SauceReporter.findErrors (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:220:25)
    at SauceReporter.reportTestRun (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:182:26)
    at SauceReporter.onEnd (/Users/alexplischke/devel/sauce-playwright-reporter/lib/reporter.js:152:32)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at ReporterV2Wrapper.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/reporterV2.js:91:12)
    at wrapAsync (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/multiplexer.js:79:12)
    at Multiplexer.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/multiplexer.js:51:25)
    at InternalReporter.onEnd (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/reporters/internalReporter.js:69:12)
    at Runner.runAllTests (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/runner/runner.js:78:28)
    at runTests (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/program.js:207:85)
    at t.<anonymous> (/Users/alexplischke/devel/saucectl-playwright-example/node_modules/playwright/lib/program.js:54:7)
```