### PR TITLE
feat: include skipped tests in report

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -8,6 +8,10 @@ import { TestCase } from '@playwright/test/reporter';
  * NOTE: This does not return the entire body of a TestCase, only the TestSteps
  */
 export function getLines(testCase: TestCase) {
+  if (testCase.results.length === 0) {
+    return [];
+  }
+
   const result = testCase.results[testCase.results.length - 1];
   const stepLines = result.steps
     .map((step) => step.location?.line)

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -361,12 +361,25 @@ export default class SauceReporter implements Reporter {
     const assets: Asset[] = [];
 
     for (const testCase of rootSuite.tests) {
-      const lastResult = testCase.results[testCase.results.length - 1];
+      let lastResult = testCase.results[testCase.results.length - 1];
 
-      // TestCase can have 0 results if it was skipped with the skip annotation or
-      // if it was filtered with the grep cli flag
+      // TestCase can have 0 results if it was skipped with the skip annotation,
+      // filtered with the grep cli flag or never executed due to early
+      // termination, such as the fail-fast option `maxFailures`.
       if (!lastResult) {
-        break;
+        lastResult = {
+          duration: 0,
+          errors: [],
+          parallelIndex: 0,
+          retry: 0,
+          startTime: this.startedAt || new Date(),
+          status: 'skipped',
+          stderr: [],
+          stdout: [],
+          steps: [],
+          workerIndex: 0,
+          attachments: [],
+        };
       }
 
       const lines = getLines(testCase);


### PR DESCRIPTION
## Description

Include skipped tests—whatever the reason may be— in the generated report: https://app.saucelabs.com/tests/4d0fe28de6004bacb3c2feaad3d2120c

This change aligns the reporter with the behavior that playwright's junit reporter exhibits.

_This does not include tests that were never meant to run if they weren't selected according to the spec pattern in the first place_.