### PR TITLE
feat: Include test tags and annotations in test report

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -433,6 +433,16 @@ export default class SauceReporter implements Reporter {
 
       const lines = getLines(testCase);
 
+      const metadata: Record<string, unknown> = {};
+      if (testCase.id) {
+        metadata.id = testCase.id;
+      }
+      if (testCase.tags.length > 0) {
+        metadata.tags = testCase.tags;
+      }
+      if (testCase.annotations.length > 0) {
+        metadata.annotations = testCase.annotations;
+      }
       const isSkipped = testCase.outcome() === 'skipped';
       const test = suite.withTest(testCase.title, {
         status: isSkipped
@@ -446,12 +456,8 @@ export default class SauceReporter implements Reporter {
           : undefined,
         startTime: lastResult.startTime,
         code: new TestCode(lines),
+        metadata,
       });
-      if (testCase.id) {
-        test.metadata = {
-          id: testCase.id,
-        };
-      }
 
       for (const attachment of lastResult.attachments) {
         if (!attachment.path && !attachment.body) {

--- a/tests/integration/playwright.config.ts
+++ b/tests/integration/playwright.config.ts
@@ -34,6 +34,10 @@ const config: PlaywrightTestConfig = {
       name: 'Failing Suites',
       testMatch: 'tests/failing.test.js',
     },
+    {
+      name: 'Annotation tests',
+      testMatch: 'tests/annotation.test.ts',
+    },
   ],
 };
 

--- a/tests/integration/tests/annotation.test.ts
+++ b/tests/integration/tests/annotation.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test('@implicit tag in title', async ({ page }) => {
+  await page.goto('https://www.saucedemo.com/');
+
+  expect(await page.title()).toBe('Swag Labs');
+});
+
+test('explicit tag argument', { tag: '@explicit' }, async ({ page }) => {
+  await page.goto('https://www.saucedemo.com/');
+
+  expect(await page.title()).toBe('Swag Labs');
+});
+
+test('built in annotation', async ({ page }) => {
+  test.slow();
+
+  await page.goto('https://www.saucedemo.com/');
+
+  expect(await page.title()).toBe('Swag Labs');
+});
+
+test(
+  'annotations',
+  { annotation: { type: 'static annotation' } },
+  async ({ page }) => {
+    test.info().annotations.push({
+      type: 'runtime annotation',
+      description: 'annotation added during test execution',
+    });
+    await page.goto('https://www.saucedemo.com/');
+
+    expect(await page.title()).toBe('Swag Labs');
+  },
+);


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

In playwright, tests can be annotated with tags and annotations: https://playwright.dev/docs/test-annotations
Capture them in the test report in a test's metadata object.

[INT-62]


[INT-62]: https://saucedev.atlassian.net/browse/INT-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ